### PR TITLE
#4 Fix inserting `@return` to void functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.9.9
+- Fix inserting `@return` to void functions
+
 ### 0.9.8
 - Fix return without type has double spaces
 - Fix extra space when no `@description` provided.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "docthis",
-  "version": "0.8.2",
+  "name": "wr-docthis",
+  "version": "0.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wr-docthis",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wr-docthis",
   "displayName": "William's Document This",
   "description": "Automatically generates detailed JSDoc comments in TypeScript and JavaScript files.",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "publisher": "WilliamRagstad",
   "icon": "images/icon.png",
   "galleryBanner": {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -114,7 +114,12 @@ export function findNonVoidReturnInCurrentScope(node: ts.Node) {
     returnNode = <ts.ReturnStatement>children.find(n => n.kind === ts.SyntaxKind.ReturnStatement);
 
     if (returnNode) {
-        if (returnNode.getChildren().length > 1) {
+        const returnStatementChildren = returnNode.getChildren();
+        const isNonVoidReturn = (
+            returnStatementChildren.length > 1 &&
+            returnStatementChildren.some(child => child.kind !== ts.SyntaxKind.SemicolonToken && child.kind !== ts.SyntaxKind.ReturnKeyword)
+        );
+        if (isNonVoidReturn) {
             return returnNode;
         }
     }

--- a/test/voidReturn.ts
+++ b/test/voidReturn.ts
@@ -1,0 +1,25 @@
+function test1(): void {
+  return
+}
+
+function test2(): void {
+  return;
+}
+
+function test3(): void {
+}
+
+function test4(): void {}
+
+function test5() {
+  return
+}
+
+function test6() {
+  return;
+}
+
+function test7() {
+}
+
+function test8() {}


### PR DESCRIPTION
A `ReturnStatment` of `return;` has 2 children, a `SemicolonToken` and a `ReturnKeyword`.  Since it is still possible that a return statement of 2 children is a non-void return statement, for example `return "value"`, I added a `some` that requires any child not to be a `SemicolonToken` or a `ReturnToken`.

I did not see any unit tests, so I did not add any. I created a demo file where every function works as expected (does not produce a `@return` tag).

I did a bigger refactor of this function, but decided to keep this PR short and limited to the issue scope.